### PR TITLE
fix/readme-and-npm-publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,4 @@
-/dist
 /node_modules
+.*
+.env
+.env*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Welcome to truesign-fastify-hook 👋</h1>
 <p>
-  <img alt="Version" src="https://img.shields.io/badge/version-1.0.0-blue.svg?cacheSeconds=2592000" />
+  <img alt="Version" src="https://img.shields.io/badge/version-2.0.2-blue.svg?cacheSeconds=2592000" />
   <a href="#" target="_blank">
     <img alt="License: ISC" src="https://img.shields.io/badge/License-ISC-yellow.svg" />
   </a>


### PR DESCRIPTION
- I updated the version badge in your README.md to 2.0.2, so it matches the version in your package.json.
- I also adjusted your .npmignore file:
    - I removed `/dist` so that your built files will be included when you publish to npm.
    - I added rules to make sure that `.env` files and any hidden files or directories (those starting with a `.`) are not included in the package.

These adjustments will make sure your README shows the correct version and that your npm package contains all the right files, while keeping out anything sensitive or not needed.