### PR TITLE
types: improvements

### DIFF
--- a/fastify.d.ts
+++ b/fastify.d.ts
@@ -1,0 +1,15 @@
+// We manually type FastifyRequest and FastifyReply to avoid adding fastify as a dependency, which makes it hard for the
+// hook to work in both Fastify v2 and v3 projects.
+//
+// This is the bare minimum we need from those types to make the hook work and be properly typed.
+
+type FastifyRequest = {
+  query: unknown;
+};
+
+type FastifyReply = {
+  code: (statusCode: number) => FastifyReply;
+  send: (body?: unknown) => void;
+};
+
+type HookHandlerDoneFunction = <TError extends Error>(err?: TError) => void

--- a/index.test.ts
+++ b/index.test.ts
@@ -1,4 +1,4 @@
-import { getTruesignHook } from './index';
+import { type DecryptedToken, getTruesignHook } from './index';
 
 function getMockResponse() {
   return {
@@ -19,7 +19,7 @@ test('Allowing unauthenticated', () => {
     encryptionKey: 'foo',
   }
   const mockCb = jest.fn();
-  const mockResponse = getMockResponse(); 
+  const mockResponse = getMockResponse();
   const mockRequest = {
     query: {
       'ts-token': '123',
@@ -38,7 +38,7 @@ test('Not allowing unauthenticated but passing empty encryptionKey', () => {
     encryptionKey: '',
   }
   const mockCb = jest.fn();
-  const mockResponse = getMockResponse(); 
+  const mockResponse = getMockResponse();
   const mockRequest = {
     query: {
       'ts-token': '123',
@@ -57,7 +57,7 @@ test('Response sending 401 if the token is not provided', () => {
     encryptionKey: 'foo',
   }
   const mockCb = jest.fn();
-  const mockResponse = getMockResponse(); 
+  const mockResponse = getMockResponse();
   const spy = jest.spyOn(mockResponse, 'code');
   const mockRequest = {
     query: { },
@@ -74,10 +74,10 @@ test('Response sending 401 if shouldAcceptToken resolves to false', () => {
     allowUnauthenticated: false,
     shouldAcceptToken: () => false,
     encryptionKey: 'foo',
-    decryptFunction: () => 'bar',
+    decryptFunction: () => ({} as unknown as DecryptedToken),
   }
   const mockCb = jest.fn();
-  const mockResponse = getMockResponse(); 
+  const mockResponse = getMockResponse();
   const spy = jest.spyOn(mockResponse, 'code');
   const mockRequest = {
     query: {
@@ -96,10 +96,10 @@ test('Allowing properly authenticated token', () => {
     allowUnauthenticated: false,
     shouldAcceptToken: () => true,
     encryptionKey: 'foo',
-    decryptFunction: () => 'bar',
+    decryptFunction: () => ({} as unknown as DecryptedToken),
   }
   const mockCb = jest.fn();
-  const mockResponse = getMockResponse(); 
+  const mockResponse = getMockResponse();
   const spy = jest.spyOn(mockResponse, 'code');
   const mockRequest = {
     query: {

--- a/index.test.ts
+++ b/index.test.ts
@@ -1,6 +1,8 @@
+/// <reference types="./fastify.d.ts" />
+
 import { type DecryptedToken, getTruesignHook } from './index';
 
-function getMockResponse() {
+function getMockResponse(): FastifyReply {
   return {
     code(n: number) {
       return {
@@ -9,7 +11,7 @@ function getMockResponse() {
         }
       }
     }
-  }
+  } as unknown as FastifyReply;
 }
 
 test('Allowing unauthenticated', () => {
@@ -24,30 +26,29 @@ test('Allowing unauthenticated', () => {
     query: {
       'ts-token': '123',
     },
-  }
+  } as unknown as FastifyRequest;
 
   const hook = getTruesignHook(config);
   hook(mockRequest, mockResponse, mockCb);
   expect(mockCb).toBeCalled();
 });
 
-test('Not allowing unauthenticated but passing empty encryptionKey', () => {
+test('Not allowing empty encryptionKey', () => {
   const config = {
     allowUnauthenticated: false,
     shouldAcceptToken: () => false,
     encryptionKey: '',
   }
-  const mockCb = jest.fn();
-  const mockResponse = getMockResponse();
-  const mockRequest = {
-    query: {
-      'ts-token': '123',
-    },
-  }
+  expect(() => getTruesignHook(config)).toThrow();
+});
 
-  const hook = getTruesignHook(config);
-  hook(mockRequest, mockResponse, mockCb);
-  expect(mockCb).toBeCalled();
+test('Allowing empty encryptionKey if unauthenticated are allowed', () => {
+  const config = {
+    allowUnauthenticated: true,
+    shouldAcceptToken: () => false,
+    encryptionKey: '',
+  }
+  expect(() => getTruesignHook(config)).not.toThrow();
 });
 
 test('Response sending 401 if the token is not provided', () => {
@@ -60,8 +61,8 @@ test('Response sending 401 if the token is not provided', () => {
   const mockResponse = getMockResponse();
   const spy = jest.spyOn(mockResponse, 'code');
   const mockRequest = {
-    query: { },
-  }
+    query: {},
+  } as unknown as FastifyRequest;
 
   const hook = getTruesignHook(config);
   hook(mockRequest, mockResponse, mockCb);
@@ -83,7 +84,7 @@ test('Response sending 401 if shouldAcceptToken resolves to false', () => {
     query: {
       'ts-token': 'jarl',
     },
-  }
+  } as unknown as FastifyRequest;
 
   const hook = getTruesignHook(config);
   hook(mockRequest, mockResponse, mockCb);
@@ -105,7 +106,7 @@ test('Allowing properly authenticated token', () => {
     query: {
       'ts-token': 'jarl',
     },
-  }
+  } as unknown as FastifyRequest;
 
   const hook = getTruesignHook(config);
   hook(mockRequest, mockResponse, mockCb);

--- a/index.ts
+++ b/index.ts
@@ -42,7 +42,7 @@ export function decryptTruesignToken(encryptionKey: string, token: string): Decr
 export type ShouldAcceptTokenFunction = (
   decryptedToken: DecryptedToken,
   options?: TruesignHookConfig,
-  ) => boolean;
+) => boolean;
 
 export interface TruesignHookConfig {
   encryptionKey: string;
@@ -52,7 +52,7 @@ export interface TruesignHookConfig {
     options?: TruesignHookConfig,
   ) => boolean;
   queryStringPath?: string;
-  decryptFunction?: Function; 
+  decryptFunction?: Function;
 }
 
 /**

--- a/index.ts
+++ b/index.ts
@@ -116,10 +116,7 @@ export type ShouldAcceptTokenFunction = (
 export interface TruesignHookConfig {
   encryptionKey: string;
   allowUnauthenticated: boolean;
-  shouldAcceptToken: (
-    decryptedToken: DecryptedToken,
-    options?: TruesignHookConfig,
-  ) => boolean;
+  shouldAcceptToken: ShouldAcceptTokenFunction;
   queryStringPath?: string;
   decryptFunction?: Function;
 }

--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,7 @@ export type DecryptedToken =
   & DecryptedTokenEmail
   & DecryptedTokenIp;
 
-export type DecryptedTokenBase = {
+type DecryptedTokenBase = {
   /**
    * `true` if the interaction is launched by a scripting or automated tool -- not a human.
    *
@@ -49,7 +49,7 @@ export type DecryptedTokenBase = {
 /**
  * Only added if an email or domain was passed on the request.
  */
-export type DecryptedTokenEmail =
+type DecryptedTokenEmail =
   | {
     /**
      * The email you passed for Truesign to verify on this request.
@@ -80,7 +80,7 @@ export type DecryptedTokenEmail =
   };
 
 /** Your user's IP. */
-export type DecryptedTokenIp =
+type DecryptedTokenIp =
   | {
     /** Your user's IPv4. */
     ipv4: string;
@@ -113,13 +113,37 @@ export type ShouldAcceptTokenFunction = (
   options?: TruesignHookConfig,
 ) => boolean;
 
-export interface TruesignHookConfig {
+export type DecryptTokenFunction = (
+  encryptionKey: string,
+  token: string,
+) => DecryptedToken;
+
+export type TruesignHookConfig = {
+  /**
+   * Token encryption key, as listed in your [Truesign dashboard](https://my.truesign.ai/dashboard#endpoints).
+   */
   encryptionKey: string;
-  allowUnauthenticated: boolean;
+  /**
+   * If `true`, the hook will allow requests without a token.
+   */
+  allowUnauthenticated?: boolean;
+  /**
+   * A function that receives the decrypted token and returns `true` if the request should be accepted.
+   */
   shouldAcceptToken: ShouldAcceptTokenFunction;
+  /**
+   * The query string key where the token is expected to be found.
+   * 
+   * Also serves as the key where the decrypted token is injected in `request` for later middlewares or route handler.
+   * 
+   * @default 'ts-token'
+   */
   queryStringPath?: string;
-  decryptFunction?: Function;
-}
+  /**
+   * Optional custom decrypt function if you want to override the default one.
+   */
+  decryptFunction?: DecryptTokenFunction;
+};
 
 /**
  * Given a TruesignHookConfig, returns a Fastify hook function (request, response, callback) 

--- a/index.ts
+++ b/index.ts
@@ -118,32 +118,39 @@ export type DecryptTokenFunction = (
   token: string,
 ) => DecryptedToken;
 
-export type TruesignHookConfig = {
-  /**
-   * Token encryption key, as listed in your [Truesign dashboard](https://my.truesign.ai/dashboard#endpoints).
-   */
-  encryptionKey: string;
-  /**
-   * If `true`, the hook will allow requests without a token.
-   */
-  allowUnauthenticated?: boolean;
-  /**
-   * A function that receives the decrypted token and returns `true` if the request should be accepted.
-   */
-  shouldAcceptToken: ShouldAcceptTokenFunction;
-  /**
-   * The query string key where the token is expected to be found.
-   * 
-   * Also serves as the key where the decrypted token is injected in `request` for later middlewares or route handler.
-   * 
-   * @default 'ts-token'
-   */
-  queryStringPath?: string;
-  /**
-   * Optional custom decrypt function if you want to override the default one.
-   */
-  decryptFunction?: DecryptTokenFunction;
-};
+/**
+ * Configuration object for the Truesign Fastify hook.
+ * 
+ * {@link Additional} can be used to extend the config with custom properties.
+ */
+export type TruesignHookConfig<Additional extends Record<string, unknown> = {}> =
+  & {
+    /**
+     * Token encryption key, as listed in your [Truesign dashboard](https://my.truesign.ai/dashboard#endpoints).
+     */
+    encryptionKey: string;
+    /**
+     * If `true`, the hook will allow requests without a token.
+     */
+    allowUnauthenticated?: boolean;
+    /**
+     * A function that receives the decrypted token and returns `true` if the request should be accepted.
+     */
+    shouldAcceptToken: ShouldAcceptTokenFunction;
+    /**
+     * The query string key where the token is expected to be found.
+     * 
+     * Also serves as the key where the decrypted token is injected in `request` for later middlewares or route handler.
+     * 
+     * @default 'ts-token'
+     */
+    queryStringPath?: string;
+    /**
+     * Optional custom decrypt function if you want to override the default one.
+     */
+    decryptFunction?: DecryptTokenFunction;
+  }
+  & Additional;
 
 /**
  * Given a TruesignHookConfig, returns a Fastify hook function (request, response, callback) 

--- a/index.ts
+++ b/index.ts
@@ -1,9 +1,5 @@
 import * as crypto from 'crypto';
 
-export interface DynamicObject {
-  [k: string]: any;
-}
-
 export interface DecryptedToken {
   anonymizer: boolean;
   notBrowser: boolean;
@@ -48,7 +44,7 @@ export type ShouldAcceptTokenFunction = (
   options?: TruesignHookConfig,
   ) => boolean;
 
-export interface TruesignHookConfig extends DynamicObject {
+export interface TruesignHookConfig {
   encryptionKey: string;
   allowUnauthenticated: boolean;
   shouldAcceptToken: (

--- a/index.ts
+++ b/index.ts
@@ -110,7 +110,7 @@ export function decryptTruesignToken(encryptionKey: string, token: string): Decr
 
 export type ShouldAcceptTokenFunction = (
   decryptedToken: DecryptedToken,
-  options?: TruesignHookConfig,
+  options: TruesignHookConfig,
 ) => boolean;
 
 export type DecryptTokenFunction = (

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "fastify-truesign",
     "truesign"
   ],
+  "files": [
+    "dist"
+  ],
   "author": "Julian Toledo",
   "license": "ISC",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "prepare": "npm run build",
     "prepublishOnly": "npm run release && npm run build",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "jest",
     "release": "standard-version"
   },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "lib": [
+      "es2017",
+      "es7",
+      "es6",
+      "dom"
+    ],
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,11 @@
 {
-  "compilerOptions": {
-    "target": "es5",
-    "module": "commonjs",
-    "lib": ["es2017", "es7", "es6", "dom"],
-    "declaration": true,
-    "outDir": "dist",
-    "strict": true,
-    "esModuleInterop": true
-  },
-  "exclude": [
-    "node_modules",
-    "dist"
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    }
   ]
 }

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -1,5 +1,10 @@
 {
   "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "types": [
+      "node"
+    ]
+  },
   "exclude": [
     "node_modules",
     "dist",

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.base.json",
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts"
+  ]
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": [
+    "**/*.test.ts"
+  ]
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,7 +1,11 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "types": [
+      "jest",
+      "node"
+    ]
   },
   "include": [
     "**/*.test.ts"


### PR DESCRIPTION
This PR contains general type improvements for the hook to match the current Truesign docs.

- Replace `DynamicObject` (which made the optional extensions to hook config too broad) with a typable generic.
- Improve token types with current docs in https://my.truesign.ai/
- Use defined function types that were exported but unused
- Improve config types
- Improve hook types with minimal Fastify-like types
- Fix type of `ShouldAcceptTokenFunction` since it always received the config but was marked as optional

Additionally:

- Do not emit tests on build
- Only include `dist` folder in NPM package to avoid pollution of types by mistake
- Fix issue where a missing `encryptionKey` never rejected the login, not even when `allowUnauthenticated` was `false`. Now the hook just throws if the encryption key is missing but unauthenticated are not explicitly allowed.
